### PR TITLE
Thêm debug argument cho web app

### DIFF
--- a/src/topdup_open/requirements.txt
+++ b/src/topdup_open/requirements.txt
@@ -1,6 +1,7 @@
 aniso8601==8.0.0
 astroid==2.4.2
 autopep8==1.5.4
+argparse==1.4.0
 cachetools==4.1.1
 click==7.1.2
 Flask==1.1.2

--- a/src/topdup_open/run_app.py
+++ b/src/topdup_open/run_app.py
@@ -2,11 +2,12 @@ import argparse
 from topdup_app import app
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="My parser")
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         "-d",
         "--debug", 
-        action='store_true'
+        action='store_true',
+        help="turn on debugging mode"
     )
     args = parser.parse_args()
     if args.debug:

--- a/src/topdup_open/run_app.py
+++ b/src/topdup_open/run_app.py
@@ -1,5 +1,16 @@
+import argparse
 from topdup_app import app
 
 if __name__ == "__main__":
-    app.run()
+    parser = argparse.ArgumentParser(description="My parser")
+    parser.add_argument(
+        "-d",
+        "--debug", 
+        action='store_true'
+    )
+    args = parser.parse_args()
+    if args.debug:
+        app.run(debug=True)
+    else:
+        app.run()
     # app.run(host='0.0.0.0', debug=True) #docker


### PR DESCRIPTION
Mình thấy để user không phải sửa code mỗi khi debug (`app.run(debug=True)`)  nên mình viết cái `argparse` để user tiện chạy app trong debuging environment (chức năng này sẽ auto-reload server khi có code thay đổi).

Usage:
```
# User vẫn có thể run web app như bình thường in production mode:
python run_app.py

# Xem argument của program:
python run_app.py --help
# hoặc
python run_app.py -h

# User có thể run web app trong development mode:
python run_app.py -d
# hoặc
python run_app.py --debug
```