### PR TITLE
Thêm api hiển thị so sánh similarity score giữa hai bài báo

### DIFF
--- a/modules/web_app/backend/.gitignore
+++ b/modules/web_app/backend/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/modules/web_app/backend/src/.sample-env
+++ b/modules/web_app/backend/src/.sample-env
@@ -1,0 +1,5 @@
+DB_USERNAME=admin
+DB_HOST=localhost
+DB_NAME=topdup_db
+DB_PASS=admin
+DB_PORT=5432

--- a/modules/web_app/backend/src/controllers/reports/reports.js
+++ b/modules/web_app/backend/src/controllers/reports/reports.js
@@ -1,0 +1,37 @@
+
+const Pool = require("pg").Pool;
+const pool = new Pool({
+    user: process.env.DB_USERNAME,
+    host: process.env.DB_HOST,
+    database: process.env.DB_NAME,
+    password: process.env.DB_PASS,
+    port: process.env.DB_PORT
+});
+
+const getSimilarity = (request, response) => {
+    // Issue 21.
+    // TODO: Have not tested this query since databse has not been setup.
+    const query = `
+        SELECT *
+        FROM public."SimilarityReport"
+        JOIN Article A1 ON 
+            public."SimilarityReport".sourceArticleId = A1.articleId
+        JOIN Article A2 ON 
+            public."SimilarityReport".targetArticleId = A2.articleId
+        JOIN Vote V ON
+            public."SimilarityReport".sourceArticleId = V.sourceArticleId
+            AND
+            public."SimilarityReport".targetArticleId = V.targetArticleId;
+    `;
+    pool.query(query, (error, results) => {
+        if (error) {
+            throw error;
+        }
+        response.status(200).json(results.rows);
+    });
+};
+
+
+export default {
+    getSimilarity
+};

--- a/modules/web_app/backend/src/routes/index.js
+++ b/modules/web_app/backend/src/routes/index.js
@@ -1,8 +1,10 @@
 import express from "express";
 const routers = express();
 import User from "./users/index"
+import Reports from "./reports/reports"
 
 routers.use("/api/v1/", User);
+routers.use("/api/v1/reports/", Reports);
 routers.get("/", (req, res) => {
   res.send("TopDup!");
 });

--- a/modules/web_app/backend/src/routes/index.js
+++ b/modules/web_app/backend/src/routes/index.js
@@ -1,7 +1,7 @@
 import express from "express";
 const routers = express();
 import User from "./users/index"
-import Reports from "./reports/reports"
+import Reports from "./reports/index"
 
 routers.use("/api/v1/", User);
 routers.use("/api/v1/reports/", Reports);

--- a/modules/web_app/backend/src/routes/reports/index.js
+++ b/modules/web_app/backend/src/routes/reports/index.js
@@ -1,0 +1,3 @@
+import ReportRouter from "./reports";
+
+export default ReportRouter

--- a/modules/web_app/backend/src/routes/reports/reports.js
+++ b/modules/web_app/backend/src/routes/reports/reports.js
@@ -1,0 +1,10 @@
+import express from "express";
+import ReportController from "../../controllers/reports/reports";
+const ReportRouter = express.Router();
+
+ReportRouter.get("/similiraty-reports",
+    // middlewares
+    ReportController.getSimilarity
+);
+
+export default ReportRouter


### PR DESCRIPTION
Reference to issue #21, e add thêm api so sánh similarity giữa source và target bảo lấy từ database và một số chức năng, cụ thể như sau:
- [x] 1) Thêm routes cho api `similarity-reports`.
- [x] 2) Thêm controller và query.
- [x] 3) Refactor database meta-data ra một file dotenv. có thể tìm thấy ở file `.sample-env`, khi dùng thì tạo file `.env` và copy vào rồi config database meta-data.
- [ ] 4) Testing (Sẽ có thể tạo issue trong tương lai khi có bộ test)