### PR TITLE
Change `sim_score` becomes omnidirectional

### DIFF
--- a/modules/ml/document_store/sql.py
+++ b/modules/ml/document_store/sql.py
@@ -175,8 +175,8 @@ class SQLDocumentStore(BaseDocumentStore):
             )
 
             document_id_AB.append(
-                sorted([row.document_id, document_id_B.first().value])
-            )
+                sorted([row.document_id, document_id_B.first().value]) + [row.value]
+            )  # row.value = `sim_score`
 
         document_id_AB.sort()
         document_id_AB = list(
@@ -189,9 +189,15 @@ class SQLDocumentStore(BaseDocumentStore):
             meta_A.update({"document_id": document_id[0]})
             meta_B.update({"document_id": document_id[1]})
             for row in meta.filter(MetaORM.document_id == document_id[0]).all():
-                meta_A.update({row.name: row.value})
+                if row.name == "sim_score":
+                    meta_A.update({row.name: document_id[2]})
+                else:
+                    meta_A.update({row.name: row.value})
             for row in meta.filter(MetaORM.document_id == document_id[1]).all():
-                meta_B.update({row.name: row.value})
+                if row.name == "sim_score":
+                    meta_B.update({row.name: document_id[2]})
+                else:
+                    meta_B.update({row.name: row.value})
 
             domain_A = meta_parser("domain", meta_A).lower()
             domain_B = meta_parser("domain", meta_B).lower()


### PR DESCRIPTION
Original:
--> means similar relationship
A --> B: score = 0.6
B --> C: score = 1
bug: the method `get_similar_documents_by_threshold` summarizes wrong information, B --> A: score = 1

Change:
A --> B: score = 0.6
B --> A: score = 0.6
By sorting a list of A and B, to keep only one order of documents (A, B); then add the existing similarity score from the relationship A --> B to this list.